### PR TITLE
Disable Minio initialization in tests

### DIFF
--- a/src/main/java/com/diploma/backend/config/MinioBucketInitializer.java
+++ b/src/main/java/com/diploma/backend/config/MinioBucketInitializer.java
@@ -8,8 +8,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
+import org.springframework.context.annotation.Profile;
 
 @Component
+@Profile("!test")
 @RequiredArgsConstructor
 public class MinioBucketInitializer implements CommandLineRunner {
 


### PR DESCRIPTION
## Summary
- avoid connecting to Minio during tests by disabling initializer via profile

## Testing
- `./gradlew test --no-daemon` *(fails: There were failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6841eb027244832faf5acd0c8536312a