### PR TITLE
Ignore build archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,12 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# Archives
+*.zip
+*.tar
+*.tar.gz
+*.tgz
+*.gz
+*.rar
+*.7z


### PR DESCRIPTION
## Summary
- update `.gitignore` to ignore common archive formats

## Testing
- `./gradlew test --no-daemon` *(fails: could not find a Java 17 installation)*

------
https://chatgpt.com/codex/tasks/task_e_6852e006c64c832fb66aa19317b7c468